### PR TITLE
chore: preinstall extra packages & minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+.env.*.local
+compose.override.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM php:8.3-cli-alpine as sio_test
 RUN apk add --no-cache git zip bash
+
+# Setup php extensions
+RUN apk add --no-cache postgresql-dev \
+    && docker-php-ext-install pdo_pgsql pdo_mysql \
+    && docker-php-source delete
+
+ENV COMPOSER_CACHE_DIR=/tmp/composer-cache
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 # Setup php app user

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ RUN apk add --no-cache git zip bash
 
 # Setup php extensions
 RUN apk add --no-cache postgresql-dev \
-    && docker-php-ext-install pdo_pgsql pdo_mysql \
-    && docker-php-source delete
+    && docker-php-ext-install pdo_pgsql pdo_mysql
 
 ENV COMPOSER_CACHE_DIR=/tmp/composer-cache
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ restart: stop start ## Restart services.
 console: ## Login in console.
 	${DC_EXEC} /bin/bash
 
-install:
+install: ## Install dependencies without running the whole application.
 	${DC_RUN} composer install
 
 success-message:

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,16 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "symfony/console": "6.4.*",
         "symfony/dotenv": "6.4.*",
         "symfony/flex": "^2",
         "symfony/framework-bundle": "6.4.*",
+        "symfony/property-access": "6.4.*",
         "symfony/runtime": "6.4.*",
+        "symfony/serializer": "6.4.*",
         "symfony/validator": "6.4.*",
         "symfony/yaml": "6.4.*",
         "systemeio/test-for-candidates": "^1.0.2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
         build:
             context: .
             args:
-                USER_ID: ${USER_ID}
+                USER_ID: ${USER_ID:-1000}
         ports:
             - "8337:8337"
         volumes:


### PR DESCRIPTION
Minor improvements and fixes aimed at improving the chances of quick task completion.
- Preinstall `pdo_pgsql` and `pdo_mysql` PHP extensions in the PHP image;
- Add `serializer` pack to `composer.json`;
- Set default `USER_ID` environment variable in `compose.yml`;
- Explicitly state that `make install` won't run the whole app;
- Add `.gitignore` with common patterns we don't want to see.
